### PR TITLE
GSoC 2020: Add Jenkins and Jenkins X links on the 2020 project ideas page

### DIFF
--- a/2020.md
+++ b/2020.md
@@ -31,5 +31,14 @@
 
 ## Jenkins
 
-## Jenkins-X
+| WARNING: This year the Jenkins project participates in GSoC as a separate GSoC mentoring organization. You can find the organizations profile and application guidelines [here](https://summerofcode.withgoogle.com/organizations/4945163270488064/). |
+| --- |
 
+List of the project ideas is available on the [Jenkins website](https://jenkins.io/projects/gsoc/2020/project-ideas/).
+
+## Jenkins X
+
+| WARNING: This year Jenkins X project participates in GSoC under umbrella of the Jenkins project. You can find the organizations profile and application guidelines [here](https://summerofcode.withgoogle.com/organizations/4945163270488064/). |
+| --- |
+
+List of the project ideas is available on the [Jenkins website](https://jenkins.io/projects/gsoc/2020/project-ideas/).


### PR DESCRIPTION
There was a new 2020 page introduced yesterday, so the references on the README page do not seem to be enough. I added references to the 2020 project ideas page as well.

CC @tracymiranda @markyjackson-taulia @martinda @Marckk
